### PR TITLE
Prevent build errors with many small css modules

### DIFF
--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -350,6 +350,7 @@ module.exports = {
     // Note: this won't work without ExtractTextPlugin.extract(..) in `loaders`.
     new ExtractTextPlugin({
       filename: cssFilename,
+      ignoreOrder: true,
     }),
     // Generate a manifest file which contains a mapping of all asset filenames
     // to their corresponding output file so that tools can pick it up without


### PR DESCRIPTION
There's a problem when building from a codebase that is using many small css modules - you get something like
```
Failed to compile.
Order in extracted chunk undefined
```
when you run `build`.
A "manual" solution would be to combine all small css modules (`links.module.css`, `buttons.module.css`, etc) into a single one (say, `styles.module.css`) and only compose from that one. It would be a shame to, though.
ExtractTextPlugin has a fix for this namely the `ignoreOrder: true` option.
See https://github.com/webpack-contrib/extract-text-webpack-plugin
Discussion with the fix: https://github.com/webpack-contrib/extract-text-webpack-plugin/pull/166#issuecomment-307414614
Comment with the "manual" fix: https://github.com/css-modules/css-modules/issues/12#issuecomment-165227881