### PR TITLE
🐛 fix mjs files resolving before js files as in CRA#4085

### DIFF
--- a/scripts/utils/createJestConfig.js
+++ b/scripts/utils/createJestConfig.js
@@ -42,6 +42,7 @@ module.exports = (resolve, rootDir, isEjecting) => {
     transformIgnorePatterns: ['[/\\\\]node_modules[/\\\\].+\\.(js|jsx|mjs)$'],
     moduleNameMapper: {
       '^react-native$': 'react-native-web',
+      '^.+\\.module\\.css$': 'identity-obj-proxy',
     },
     moduleFileExtensions: [
       'web.js',

--- a/scripts/utils/createJestConfig.js
+++ b/scripts/utils/createJestConfig.js
@@ -42,16 +42,15 @@ module.exports = (resolve, rootDir, isEjecting) => {
     transformIgnorePatterns: ['[/\\\\]node_modules[/\\\\].+\\.(js|jsx|mjs)$'],
     moduleNameMapper: {
       '^react-native$': 'react-native-web',
-      '^.+\\.module\\.css$': 'identity-obj-proxy',
     },
     moduleFileExtensions: [
       'web.js',
-      'mjs',
       'js',
       'json',
       'web.jsx',
       'jsx',
       'node',
+      'mjs',
     ],
   };
   if (rootDir) {


### PR DESCRIPTION
### Actions:
- 🐛 fix mjs files resolving before js files as in [CRA#4085](https://github.com/facebook/create-react-app/pull/4085)

### Description: 
A bug was found in CRA jest config where `mjs` files resolve before `js` files, this breaks support for using GraphQL (relay, apollo, etc) within create-react-app projects. This PR fixes this bug.